### PR TITLE
libwebp 1.3.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         libwebp-version: ['1.3.0', '1.3.1']
         go-version: ['~1.18', '~1.19', '~1.20']
+        extldflags: ['', '-static']
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -34,6 +35,7 @@ jobs:
           echo "CGO_CFLAGS=-I $HOME/cache/libwebp-${{ matrix.libwebp-version }}/include" >> $GITHUB_ENV
           echo "CGO_LDFLAGS=-L $HOME/cache/libwebp-${{ matrix.libwebp-version }}/lib" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$HOME/cache/libwebp-${{ matrix.libwebp-version }}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "GOLIBWEBP_EXTLDFLAGS=${{ matrix.extldflags }}" >> $GITHUB_ENV
       - name: build libwebp
         run: LIBWEBP_PREFIX=$HOME/cache/libwebp-${{ matrix.libwebp-version }} make libwebp
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: test
     strategy:
       matrix:
-        libwebp-version: ['0.4.1', '0.4.2', '0.4.3', '0.5.0', '0.5.1']
+        libwebp-version: ['1.3.0', '1.3.1']
         go-version: ['~1.18', '~1.19', '~1.20']
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /tmp/go-libwebp
 COPY Makefile /tmp/go-libwebp/Makefile
 
 ENV LIBWEBP_PREFIX="/usr/local" \
-    LIBWEBP_VERSION="0.5.1"
+    LIBWEBP_VERSION="1.3.1"
 RUN cd /tmp/go-libwebp && make libwebp
 
 ENV GOPATH="/go" \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LIBWEBP_VERSION ?= 1.3.1
 all: test
 
 test:
-	go test -v ./...
+	go test -v --ldflags "-extldflags '$(GOLIBWEBP_EXTLDFLAGS)'" ./...
 
 libwebp: $(libwebp_so)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ repo = github.com/pixiv/go-libwebp
 build_dir = /tmp
 cur_dir = $(shell pwd)
 libwebp_so = ${LIBWEBP_PREFIX}/lib/libwebp.so
-LIBWEBP_VERSION ?= 0.5.1
+LIBWEBP_VERSION ?= 1.3.1
 
 all: test
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A implementation of Go binding for [libwebp](https://developers.google.com/speed
 
 ## Dependencies
 
-- libwebp 0.4, 0.5
+- libwebp 1.3.0 and above
 
 ## Usage
 

--- a/webp/webp.go
+++ b/webp/webp.go
@@ -3,7 +3,7 @@
 package webp
 
 /*
-#cgo LDFLAGS: -lwebp -lm
+#cgo LDFLAGS: -lwebp -lsharpyuv -lm
 
 #include <stdlib.h>
 #include <webp/encode.h>


### PR DESCRIPTION
- Link libsharpyuv explicitly to support libwebp 1.3.0 and above
  - libwebp below 1.3.0 are no longer supported
- Add tests with static linkage
- Update README.md
