### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pixiv/go-libwebp/security/code-scanning/1](https://github.com/pixiv/go-libwebp/security/code-scanning/1)

To fix this issue, we need to add a `permissions` block to the workflow to explicitly limit the default permissions for the `GITHUB_TOKEN`. The best way is to add this block at the workflow root level (just after the `name:` and before `on:`) so that it applies to all jobs in the workflow (since the workflow currently has only one job, `test`). The minimal starting point is `contents: read`, which allows jobs to clone the repository but does not allow any write actions. This change involves adding the following block to the top of the file:
```yaml
permissions:
  contents: read
```
No imports, methods, or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
